### PR TITLE
Configure maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
@@ -90,5 +94,12 @@
             </snapshots>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>


### PR DESCRIPTION
## Summary
- use Maven Central for non Embabel dependencies in pom.xml
- ensure plugins can be resolved from central as well

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.springframework.boot... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68836e4868f4832bbf20d941fa635e99